### PR TITLE
mention related actively maintained project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ It can help you clean up empty files and unused attachments in the obsidian vaul
 ### Known issue
 
 -   Attachments used in [Admonition](https://github.com/valentine195/obsidian-admonition) code blocks are not recognized
+
+## ⚠️ Related Project
+
+There is an actively maintained and more feature-complete related project:  
+[obsidian-file-cleaner-redux](https://github.com/husjon/obsidian-file-cleaner-redux) by [husjon](https://github.com/husjon).
+
+If you are looking for additional features or recent updates, you may want to check it out.


### PR DESCRIPTION
- Documentation only (README)
- No functional or behavioral changes

This PR adds a small informational note to the README pointing to [obsidian-file-cleaner-redux](https://github.com/husjon/obsidian-file-cleaner-redux) as a related, actively maintained project.

Some users and contributors may be looking for newer features or recent updates and may not be aware of the other project. This change helps set expectations and reduces duplicated effort, while remaining neutral about the future direction of this repository.